### PR TITLE
fix: Enable configuration for Redis usage

### DIFF
--- a/app/commons/JedisFactory.java
+++ b/app/commons/JedisFactory.java
@@ -9,6 +9,7 @@ import utils.DialCodeEnum;
 public class JedisFactory {
 
 	private static JedisPool jedisPool;
+	private static boolean redisEnabled = AppConfig.getBoolean("redis.cache.enabled", false);
 
 	private static int maxConnections = 128;
 	private static String host = "localhost";
@@ -16,17 +17,25 @@ public class JedisFactory {
 	private static int index = 0;
 
 	static {
-		if (AppConfig.config.hasPath("redis.host")) host = AppConfig.config.getString("redis.host");
-		if (AppConfig.config.hasPath("redis.port")) port = AppConfig.config.getInt("redis.port");
-		if (AppConfig.config.hasPath("redis.maxConnections")) maxConnections = AppConfig.config.getInt("redis.maxConnections");
-		if (AppConfig.config.hasPath("redis.dbIndex")) index = AppConfig.config.getInt("redis.dbIndex");
-		JedisPoolConfig config = new JedisPoolConfig();
-		config.setMaxTotal(maxConnections);
-		config.setBlockWhenExhausted(true);
-		jedisPool = new JedisPool(config, host, port);
+		if (redisEnabled) {
+			if (AppConfig.config.hasPath("redis.host")) host = AppConfig.config.getString("redis.host");
+			if (AppConfig.config.hasPath("redis.port")) port = AppConfig.config.getInt("redis.port");
+			if (AppConfig.config.hasPath("redis.maxConnections")) maxConnections = AppConfig.config.getInt("redis.maxConnections");
+			if (AppConfig.config.hasPath("redis.dbIndex")) index = AppConfig.config.getInt("redis.dbIndex");
+			JedisPoolConfig config = new JedisPoolConfig();
+			config.setMaxTotal(maxConnections);
+			config.setBlockWhenExhausted(true);
+			jedisPool = new JedisPool(config, host, port);
+		}
+	}
+
+	public static boolean isEnabled() {
+		return redisEnabled;
 	}
 
 	public static Jedis getRedisConncetion() {
+		if (!redisEnabled)
+			throw new ServerException(DialCodeEnum.ERR_CACHE_CONNECTION_ERROR.name(), "Redis cache is disabled.");
 		try {
 			Jedis jedis = jedisPool.getResource();
 			if (index > 0)
@@ -38,6 +47,7 @@ public class JedisFactory {
 	}
 
 	public static void returnConnection(Jedis jedis) {
+		if (!redisEnabled) return;
 		try {
 			if (null != jedis)
 				jedisPool.returnResource(jedis);

--- a/app/dbstore/SystemConfigStore.java
+++ b/app/dbstore/SystemConfigStore.java
@@ -3,8 +3,12 @@
  */
 package dbstore;
 
+import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
 import commons.AppConfig;
+import utils.CassandraConnector;
 import utils.DialCodeEnum;
 
 import java.util.HashMap;
@@ -37,5 +41,40 @@ public class SystemConfigStore extends CassandraStore {
 		Map<String, Object> data = new HashMap<String, Object>();
 		data.put(DialCodeEnum.prop_value.name(), String.valueOf((int) maxIndex));
 		update(DialCodeEnum.prop_key.name(), DialCodeEnum.dialcode_max_index.name(), data, null);
+	}
+
+	/**
+	 * Atomically increments the dialcode_max_index using a Cassandra
+	 * Lightweight Transaction (compare-and-set). Retries on CAS conflict to
+	 * safely support concurrent requests and multiple service instances when
+	 * Redis is disabled.
+	 *
+	 * @return the new (incremented) index value
+	 * @throws Exception if the row is missing or all retries are exhausted
+	 */
+	public Double getAndIncrementDialCodeIndex() throws Exception {
+		int maxRetries = 10;
+		for (int i = 0; i < maxRetries; i++) {
+			List<Row> rows = read(DialCodeEnum.prop_key.name(), DialCodeEnum.dialcode_max_index.name());
+			if (rows.isEmpty())
+				throw new Exception("dialcode_max_index not found in system_config");
+			Row row = rows.get(0);
+			String currentStr = row.getString(DialCodeEnum.prop_value.name());
+			double current = Double.valueOf(currentStr);
+			double next = current + 1;
+			String nextStr = String.valueOf((int) next);
+			Statement stmt = QueryBuilder.update(getKeyspace(), getTable())
+					.with(QueryBuilder.set(DialCodeEnum.prop_value.name(), nextStr))
+					.where(QueryBuilder.eq(DialCodeEnum.prop_key.name(), DialCodeEnum.dialcode_max_index.name()))
+					.onlyIf(QueryBuilder.eq(DialCodeEnum.prop_value.name(), currentStr));
+			ResultSet rs = CassandraConnector.getSession().execute(stmt);
+			Row applied = rs.one();
+			if (applied.getBool("[applied]")) {
+				return next;
+			}
+			// Another instance won the CAS race; re-read and retry.
+		}
+		throw new Exception("Failed to allocate DIAL code index after " + maxRetries
+				+ " retries due to high concurrency.");
 	}
 }

--- a/app/managers/HealthCheckManager.java
+++ b/app/managers/HealthCheckManager.java
@@ -4,6 +4,7 @@
  */
 package managers;
 
+import commons.JedisFactory;
 import commons.dto.Response;
 import commons.exception.ResponseCode;
 import telemetry.TelemetryManager;
@@ -39,20 +40,22 @@ public class HealthCheckManager extends BaseManager implements IHealthCheckManag
 
         allChecks.add(check);
         check = new HashMap<>();
-        try{
-            status = IHealthCheckManager.checkRedisHealth();
-            if(!status){
-                overAllHealth=false;
+        if (JedisFactory.isEnabled()) {
+            try {
+                status = IHealthCheckManager.checkRedisHealth();
+                if (!status) {
+                    overAllHealth = false;
+                }
+                check = generateCheck("redis cache", check, status);
+                TelemetryManager.log("redis cache " + CONNECTION_SUCCESS);
+            } catch (Exception e) {
+                check = generateCheck("redis cache", check, status);
+                TelemetryManager.error("redis cache " + CONNECTION_FAIL, e);
             }
-            check = generateCheck("redis cache",check,status);
-            TelemetryManager.log("redis cache "+CONNECTION_SUCCESS);
-        }catch (Exception e){
-            check = generateCheck("redis cache",check,status);
-            TelemetryManager.error("redis cache "+CONNECTION_FAIL,e);
+            allChecks.add(check);
+            check = new HashMap<>();
         }
 
-        allChecks.add(check);
-        check = new HashMap<>();
         try{
             status = IHealthCheckManager.checkCassandraHealth();
             check = generateCheck("cassandra db",check,status);
@@ -66,11 +69,14 @@ public class HealthCheckManager extends BaseManager implements IHealthCheckManag
         }
         allChecks.add(check);
 
-        check = generateCheck("DIAL Max Index", check, dialMaxIndexHealth);
-        if (!dialMaxIndexHealth) {
-            overAllHealth = false;
+        if (JedisFactory.isEnabled()) {
+            check = new HashMap<>();
+            check = generateCheck("DIAL Max Index", check, dialMaxIndexHealth);
+            if (!dialMaxIndexHealth) {
+                overAllHealth = false;
+            }
+            allChecks.add(check);
         }
-        allChecks.add(check);
 
         Response response = OK("checks",allChecks);
         if(!overAllHealth)

--- a/app/managers/IHealthCheckManager.java
+++ b/app/managers/IHealthCheckManager.java
@@ -19,6 +19,7 @@ public interface IHealthCheckManager {
     Response getAllServiceHealth();
 
     static boolean checkRedisHealth(){
+        if (!JedisFactory.isEnabled()) return true;
         try {
             Jedis jedis = JedisFactory.getRedisConncetion();
             jedis.close();

--- a/app/utils/DialCodeGenerator.java
+++ b/app/utils/DialCodeGenerator.java
@@ -1,6 +1,7 @@
 package utils;
 
 import commons.AppConfig;
+import commons.JedisFactory;
 import dbstore.DialCodeStore;
 import dbstore.SystemConfigStore;
 import org.apache.commons.lang3.StringUtils;
@@ -75,6 +76,9 @@ public class DialCodeGenerator {
 	 * @throws Exception
 	 */
 	private Double getMaxIndex(Double masterDBIndex) throws Exception {
+		if (!JedisFactory.isEnabled()) {
+			return masterDBIndex + 1;
+		}
 		double index = RedisStoreUtil.getNodePropertyIncVal("domain", "dialcode", "max_index");
 		if (index < masterDBIndex) {
 		    String message = "Redis doesn't have the latest max index. Please set max index in redis as : " + masterDBIndex + " to enable the service.";

--- a/app/utils/DialCodeGenerator.java
+++ b/app/utils/DialCodeGenerator.java
@@ -53,7 +53,12 @@ public class DialCodeGenerator {
 				}
 			}
 		}
-		setMaxIndex(lastIndex);
+		// When Redis is enabled the counter lives in Redis; sync it back to Cassandra.
+		// When Redis is disabled each index was already committed atomically via CAS,
+		// so a plain write here would be redundant and unsafe under concurrency.
+		if (JedisFactory.isEnabled()) {
+			setMaxIndex(lastIndex);
+		}
 		return codes;
 	}
 
@@ -77,7 +82,9 @@ public class DialCodeGenerator {
 	 */
 	private Double getMaxIndex(Double masterDBIndex) throws Exception {
 		if (!JedisFactory.isEnabled()) {
-			return masterDBIndex + 1;
+			// Use a Cassandra LWT-based atomic increment so that concurrent
+			// requests and multiple service instances cannot allocate the same index.
+			return systemConfigStore.getAndIncrementDialCodeIndex();
 		}
 		double index = RedisStoreUtil.getNodePropertyIncVal("domain", "dialcode", "max_index");
 		if (index < masterDBIndex) {

--- a/app/utils/RedisStoreUtil.java
+++ b/app/utils/RedisStoreUtil.java
@@ -1,5 +1,6 @@
 package utils;
 
+import commons.JedisFactory;
 import commons.exception.ServerException;
 import redis.clients.jedis.Jedis;
 
@@ -10,9 +11,8 @@ public class RedisStoreUtil {
 	private static final String KEY_SEPARATOR = ":";
 
 	public static void saveNodeProperty(String graphId, String objectId, String nodeProperty, String propValue) {
-
-		Jedis jedis =
-				getRedisConncetion();
+		if (!JedisFactory.isEnabled()) return;
+		Jedis jedis = getRedisConncetion();
 		try {
 			String redisKey = getNodePropertyKey(graphId, objectId, nodeProperty);
 			jedis.set(redisKey, propValue);
@@ -24,7 +24,7 @@ public class RedisStoreUtil {
 	}
 
 	public static Double getNodePropertyIncVal(String graphId, String objectId, String nodeProperty) {
-
+		if (!JedisFactory.isEnabled()) return null;
 		Jedis jedis = getRedisConncetion();
 		try {
 			String redisKey = getNodePropertyKey(graphId, objectId, nodeProperty);

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -124,6 +124,7 @@ logger.application=DEBUG
 
 # Cache-Manager Configuration
 cache.type="redis"
+redis.cache.enabled=false
 
 #search.es_conn_info="10.6.0.11:9200"
 search.es_conn_info="localhost:9200"

--- a/test/manager/DialCodeManagerImplTest.java
+++ b/test/manager/DialCodeManagerImplTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**

--- a/test/manager/DialCodeManagerImplTest.java
+++ b/test/manager/DialCodeManagerImplTest.java
@@ -395,6 +395,36 @@ public class DialCodeManagerImplTest extends CassandraTestSetup {
 		Assert.assertEquals("CLIENT_ERROR", response.getResponseCode().toString());
 	}
 
+	/**
+	 * When Redis is disabled (default in tests), two sequential generation
+	 * requests must produce non-overlapping DIAL codes, proving that the
+	 * Cassandra LWT-based index allocator does not re-use indices.
+	 */
+	@Test
+	public void generateDialCodesProduceUniqueIndicesWhenRedisDisabledTest() throws Exception {
+		String channelId = "channelTest";
+
+		String req1 = "{\"count\":3,\"publisher\": \"mock_pub01\",\"batchCode\":\"test_idx_batch1\"}";
+		Response resp1 = dialCodeMgr.generateDialCode(getRequestMap(req1), channelId);
+		assertEquals("OK", resp1.getResponseCode().toString());
+		@SuppressWarnings("unchecked")
+		Collection<String> codes1 = (Collection<String>) resp1.getResult().get("dialcodes");
+		assertEquals(3, codes1.size());
+
+		String req2 = "{\"count\":3,\"publisher\": \"mock_pub01\",\"batchCode\":\"test_idx_batch2\"}";
+		Response resp2 = dialCodeMgr.generateDialCode(getRequestMap(req2), channelId);
+		assertEquals("OK", resp2.getResponseCode().toString());
+		@SuppressWarnings("unchecked")
+		Collection<String> codes2 = (Collection<String>) resp2.getResult().get("dialcodes");
+		assertEquals(3, codes2.size());
+
+		Set<String> firstBatch = new HashSet<>(codes1);
+		for (String code : codes2) {
+			assertFalse("Index re-use detected: code " + code + " was allocated in both batches",
+					firstBatch.contains(code));
+		}
+	}
+
 	@Test
 	public void generateDialCodeExpectValidUniqueDialCodes() throws Exception {
 		String dialCodeGenReq = "{\"count\":900}";

--- a/test/manager/HealthCheckManagerTest.java
+++ b/test/manager/HealthCheckManagerTest.java
@@ -9,6 +9,9 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.List;
+import java.util.Map;
+
 import static org.junit.Assert.*;
 
 public class HealthCheckManagerTest extends CassandraTestSetup{
@@ -33,6 +36,34 @@ public class HealthCheckManagerTest extends CassandraTestSetup{
         assertSame(goodHealth,Boolean.parseBoolean(actualHealth.getResult().get("healthy").toString()));
         assertEquals(responseCode,actualHealth.getResponseCode().name());
 
+    }
+
+    /**
+     * When Redis is disabled (default in tests), the health response must contain
+     * elasticsearch and cassandra db checks but must NOT contain redis cache or
+     * DIAL Max Index checks.
+     */
+    @Test
+    public void getAllServicesHealthWithRedisDisabledTest() throws Exception {
+        // redis.cache.enabled defaults to false in the test config
+        Response response = healthCheckManager.getAllServiceHealth();
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> checks = (List<Map<String, Object>>) response.getResult().get("checks");
+        assertNotNull("checks list must be present in health response", checks);
+
+        boolean hasEs = false, hasCassandra = false, hasRedis = false, hasDialMaxIndex = false;
+        for (Map<String, Object> check : checks) {
+            String name = (String) check.get("name");
+            if ("elasticsearch".equals(name))   hasEs = true;
+            if ("cassandra db".equals(name))    hasCassandra = true;
+            if ("redis cache".equals(name))     hasRedis = true;
+            if ("DIAL Max Index".equals(name))  hasDialMaxIndex = true;
+        }
+
+        assertTrue("elasticsearch check must be present", hasEs);
+        assertTrue("cassandra db check must be present", hasCassandra);
+        assertFalse("redis cache check must not be present when Redis is disabled", hasRedis);
+        assertFalse("DIAL Max Index check must not be present when Redis is disabled", hasDialMaxIndex);
     }
 
     @Test

--- a/test/resources/application.conf
+++ b/test/resources/application.conf
@@ -113,6 +113,7 @@ logger.application=DEBUG
 
 # Cache-Manager Configuration
 cache.type="redis"
+redis.cache.enabled=false
 
 #search.es_conn_info="10.6.0.11:9200"
 search.es_conn_info="localhost:9200"


### PR DESCRIPTION
## Summary

This PR makes Redis **fully optional** for the DIAL code service. When `redis.cache.enabled=false` (the new default), the service operates entirely on Cassandra with no dependency on a running Redis instance, while preserving correctness and concurrency safety.

---

## Problem

Previously Redis was a hard runtime requirement for DIAL code generation. The `dialcode_max_index` counter lived primarily in Redis, and the service would throw an error if Redis was unavailable or its counter had drifted behind Cassandra. There was no supported path to run the service without Redis.

---

## Changes

### `app/commons/JedisFactory.java`
- Reads `redis.cache.enabled` config flag (default `false`) at startup.
- Only creates the Redis connection pool when the flag is `true`.
- `isEnabled()` is the single gate used by all other classes — no other code touches Redis directly without checking this first.

### `app/utils/RedisStoreUtil.java`
- All methods now guard with `JedisFactory.isEnabled()` and return safely (`null` / no-op) when Redis is disabled, removing any risk of NPE if called when Redis is off.

### `app/dbstore/SystemConfigStore.java` — new method `getAndIncrementDialCodeIndex()`
- Implements a **Cassandra Lightweight Transaction (CAS)** loop to atomically increment `dialcode_max_index`.
- Uses `UPDATE … SET prop_value = N+1 WHERE prop_key = 'dialcode_max_index' IF prop_value = N` executed directly via `CassandraConnector.getSession()` (not the inherited `PreparedStatement` helper, which cannot return the `[applied]` column).
- On a CAS conflict (concurrent request won the race), re-reads and retries — up to 10 times — before throwing.
- This replaces Redis `INCRBY` as the atomic counter when Redis is disabled, making Cassandra the single authoritative counter.

### `app/utils/DialCodeGenerator.java`
- **`getMaxIndex()`**: when Redis is disabled, delegates each index allocation to `getAndIncrementDialCodeIndex()` (CAS-based) instead of Redis `INCRBY`.
- **`generate()`**: guards the final `setMaxIndex()` (the Redis→Cassandra sync write) behind `JedisFactory.isEnabled()`.  
  When Redis is disabled this write is **intentionally skipped** — Cassandra already holds the committed index from the CAS loop, and a plain write at the end would race with concurrent requests and could overwrite a higher index.

### `app/managers/HealthCheckManager.java` & `IHealthCheckManager.java`
- The **"redis cache"** and **"DIAL Max Index"** health checks are now gated behind `JedisFactory.isEnabled()`.
- When Redis is disabled, neither check appears in the `/health` response — only `elasticsearch` and `cassandra db` are reported.
- `IHealthCheckManager.checkRedisHealth()` returns `true` immediately when Redis is disabled (no false-positive failures).

### `conf/application.conf`
- Added `redis.cache.enabled=false` as the explicit default, making the no-Redis path the safe out-of-the-box configuration.

### `test/resources/application.conf`
- Added `redis.cache.enabled=false` explicitly so test intent is self-documenting and tests are protected from future default changes.

### `test/manager/DialCodeManagerImplTest.java`
- Added `generateDialCodesProduceUniqueIndicesWhenRedisDisabledTest`: generates two sequential batches of 3 DIAL codes each and asserts no code appears in both batches, proving the CAS allocator never re-uses an index.
- Fixed missing `import static org.junit.Assert.assertFalse` (compilation error).

### `test/manager/HealthCheckManagerTest.java`
- Added `getAllServicesHealthWithRedisDisabledTest`: asserts that `elasticsearch` and `cassandra db` checks are present, and that `redis cache` and `DIAL Max Index` checks are **absent** when Redis is disabled.

### `build/build.sh`
- Added `--platform linux/amd64` to the Docker build command to produce the correct image architecture when building on Apple Silicon machines.

---

## How index allocation works — before vs after

| | Redis enabled (before) | Redis disabled (after) |
|---|---|---|
| **Live counter** | Redis `INCRBY` | Cassandra LWT (`IF prop_value = N`) |
| **Cassandra role** | Checkpoint / backup | Authoritative source of truth |
| **`setMaxIndex()` after generate** | Called — syncs Redis → Cassandra | Skipped — Cassandra already holds the committed value |
| **Health checks** | ES + Cassandra + Redis Cache + DIAL Max Index | ES + Cassandra only |
| **Failure if counter store restarts** | Yes — Redis restart resets counter, causes duplicates | No — Cassandra is durable |

---

## Test plan

- [ ] Run full test suite: `sbt test` (or `mvn test`) passes with `redis.cache.enabled=false`.
- [ ] `generateDialCodesProduceUniqueIndicesWhenRedisDisabledTest` passes — no index reuse across sequential generation requests.
- [ ] `getAllServicesHealthWithRedisDisabledTest` passes — only ES and Cassandra checks appear in `/health`.
- [ ] Existing `getAllServicesHealthTest`, `checkCassandraHealth`, `checkElasticSearchHealth`, `checkRedisHealth` all continue to pass.
- [ ] Manual: start service with `redis.cache.enabled=false` and no Redis running — `POST /v1/dialcode/generate` succeeds and returns unique codes.
- [ ] Manual: start service with `redis.cache.enabled=true` and Redis running — existing Redis-backed flow is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)