### PR TITLE
fix(security): parameterize readByUUID to close CQL injection (H1)

### DIFF
--- a/app/dbstore/CassandraStore.java
+++ b/app/dbstore/CassandraStore.java
@@ -141,13 +141,16 @@ public abstract class CassandraStore {
 
     }
 
-    protected List<Row> readByUUID(String key, Object value) {
+    protected List<Row> readByUUID(String key, java.util.UUID value) {
         try {
             if (StringUtils.isBlank(key)) {
                 throw new ServerException(CassandraStoreParam.ERR_SERVER_ERROR.name(),
                         "Invalid Identifier to read");
             }
-            String selectQuery = "select * from " + keyspace+"."+table + " where " + key + "=" + value + ";";
+            // Build via QueryBuilder so the UUID is bound through its TypeCodec instead of
+            // being concatenated into the CQL string (closes CQL injection at CassandraStore.java).
+            Select selectQuery = QueryBuilder.select().all().from(keyspace, table);
+            selectQuery.where(QueryBuilder.eq(key, value));
             ResultSet results = CassandraConnector.getSession().execute(selectQuery);
             return results.all();
         } catch (Exception e) {

--- a/app/dbstore/QRCodesStore.java
+++ b/app/dbstore/QRCodesStore.java
@@ -42,7 +42,10 @@ public class QRCodesStore extends CassandraStore {
 	public QRCodesBatch read(String processId) throws Exception {
 		QRCodesBatch qrCodesBatchObj = null;
 		try {
-			List<Row> rows = readByUUID(DialCodeEnum.processid.name(), processId);
+			// processid is a uuid column; parse+validate before the DB call. A malformed id
+			// (incl. any CQL-injection payload) fails here and is surfaced as not-found below.
+			java.util.UUID processUuid = java.util.UUID.fromString(StringUtils.trimToEmpty(processId));
+			List<Row> rows = readByUUID(DialCodeEnum.processid.name(), processUuid);
 			Row row = rows.get(0);
 			qrCodesBatchObj = setQRCodesBatchData(row);
 		} catch (Exception e) {


### PR DESCRIPTION
## Summary
Closes the **CQL injection (H1, P0)** in [`implementation-designs/sunbird-dial-service.md`](../../implementation-designs/sunbird-dial-service.md).

### The vulnerability
`CassandraStore.readByUUID` built CQL by **raw string concatenation**:
```java
String selectQuery = "select * from " + keyspace+"."+table + " where " + key + "=" + value + ";";
```
Its only caller, `QRCodesStore.read`, passed the **un-sanitized `:processid` path param** from `GET /dialcode/v4/batch/read/:processid` straight into `value`, so a crafted `processid` injected CQL.

### The fix
- `readByUUID` now builds the query with `QueryBuilder.eq(key, value)` — the value is bound through its `TypeCodec` instead of concatenated (mirrors the sibling `read()` already in this class). Signature tightened to `java.util.UUID` (`processid` is a `uuid` column; single caller).
- `QRCodesStore.read` parses the path param via `UUID.fromString` **before** the DB call, so any malformed id — including an injection payload like `x' OR 1=1--` — is rejected up front.

`key` is a compile-time enum name (`DialCodeEnum.processid.name()`), never user input.

## Backward compatibility
Response for valid UUIDs is unchanged. Malformed input still surfaces as `ERR_QRCODES_BATCH_INFO` (not-found) via the existing catch, preserving current client behaviour. No DB/schema change.

## Verification
- `mvn test-compile` under **JDK 11** — exit 0; both `CassandraStore` and `QRCodesStore` recompiled.

_Note: two pre-existing tracked deletions under `build/` in the working tree are unrelated and excluded from this branch._